### PR TITLE
Compatibility fix: Set 'load' handler prior to 'src' attribute.

### DIFF
--- a/js/jquery.ez-bg-resize.js
+++ b/js/jquery.ez-bg-resize.js
@@ -22,7 +22,7 @@
 			jqez.img = [tmp_img]
 		}
 		
-		$("<img/>").attr("src", jqez.img).load(function() {
+		$("<img/>").load(function() {
 			jqez.width = this.width;
 			jqez.height = this.height;
 			
@@ -41,7 +41,7 @@
 	        });
 
 			resizeImage();
-		});
+		}).attr("src", jqez.img);
     };
 
 	$(window).bind("resize", function() {


### PR DESCRIPTION
Major (and simple) browser compatibility fix for IE when background image is cached.

As per http://www.thefutureoftheweb.com/blog/image-onload-isnt-being-called, setting 'src' attribute on a cached image in IE will _instantly_ fire 'load' event.  Thus, as we currently set the 'src' prior to 'bind', we will cause an event handler to be setup after the event (load) has already been triggered.  This causes a complete breakdown of ezBgResize on IE8 (and likely other versions / browsers).  Simply setting the binding prior to the source fixes this issue.
