### PR TITLE
IE7 CSS cascade bug

### DIFF
--- a/js/jquery.ez-bg-resize.js
+++ b/js/jquery.ez-bg-resize.js
@@ -115,12 +115,7 @@
         $("#jq_ez_bg").css({
 			"visibility" : "visible"
 		});
-
-		// Allow scrolling again
-		$("body").css({
-            "overflow":"auto"
-        });
-		
+	
         
     }
 })(jQuery);


### PR DESCRIPTION
Fixes a very obscure error in IE7. Under some cases that overflow:auto will cascade into other elements causing scroll bars to appear on various elements. In addition, there seems to be no logical reason why it is needed. 

Test case done at 1920x1080 in IE7 using a div with width:100%;height:60px;overflow:none; with a child element with a height of 75.

Before the fix a horizontal and vertical scroll bar would appear.
After the fix the scroll bars vanished. The body scroll bars still existed and the rest of the document works fine.
