### PR TITLE
fix cached img bug in IE7

### DIFF
--- a/js/jquery.ez-bg-resize.js
+++ b/js/jquery.ez-bg-resize.js
@@ -22,7 +22,7 @@
 			jqez.img = [tmp_img]
 		}
 		
-		$("<img/>").attr("src", jqez.img).load(function() {
+		$("<img/>").load(function() {
 			jqez.width = this.width;
 			jqez.height = this.height;
 			
@@ -41,7 +41,7 @@
 	        });
 
 			resizeImage();
-		});
+		}).attr("src", jqez.img);
     };
 
 	$(window).bind("resize", function() {


### PR DESCRIPTION
Just a small fix. In IE6/7, load callback function is not called if the images have been cached. 

Replaced:
$("<img/>").attr("src", jqez.img).load(function() {.....})

By:
$("<img/>").load(function() {.....}).attr("src", jqez.img)
